### PR TITLE
Fix crash

### DIFF
--- a/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.m
+++ b/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.m
@@ -40,6 +40,8 @@
 
 - (void) dealloc
 {
+    [tokenConnection setDelegate:nil];
+
     [_clientId release];
     [_scopes release];
     [_refreshToken release];


### PR DESCRIPTION
Nillify connection delegate before deallocating LiveAuthRefreshRequest.

Fixes crash.
