### PR TITLE
Replacing existing license with Apache 2.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,72 +1,13 @@
-MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
-LIVE SDK for iOS
-These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you.  Please read them.  They apply to the pre-release software named above, which includes the media on which you received it, if any.  The terms also apply to any Microsoft
-*	updates,
-*	supplements,
-*	Internet-based services, and 
-*	support services
-for this software, unless other terms accompany those items.  If so, those terms apply.
-BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS.  IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE.
-If you comply with these license terms, you have the rights below.
-1.	PRE-RELEASE SOFTWARE.  This software is a pre-release version.  It may not operate correctly or work the way a final version of the software will.  Microsoft may change it for the final, commercial version.  We also may not release a commercial version.  IF YOU DECIDE TO MAKE USE OF ANY OF THE RIGHTS UNDER THIS AGREEMENT YOU AGREE THAT IT IS AT YOUR SOLE DISCRETION AND YOU ASSUME ALL RESPONSIBILITY FOR AND RISK OF ANY AND ALL DAMAGES THAT MAY RESULT FROM OR IN CONNECTION WITH THE SOFTWARE, INCLUDING WITHOUT LIMITATION, THE UNAVAILABILITY OR INTERUPTION OF OPERATIONS OR THE LOSS OF ANY DATA OR OTHER CONTENT.
-2.	TERM.  The term of this agreement is until December 31, 2014, or commercial release of the software, whichever is first.
-3.	INSTALLATION, USE RIGHTS AND RESTRICTIONS. You may install and use any number of copies of the software on your premises as follows:
-a.	Internal Production Use.  If you comply with the rest of these license terms, you may use the software to design, develop and test your programs in a live production environment for your internal use, provided that:
-i.	you take adequate precautionary measures to back up and protect your data; 
-ii.	you agree to cease such use immediately upon notice from Microsoft; and 
-iii.	such production environment may only be accessible by your employees and contractors. 
-b.	External Production Use.  If you comply with the rest of these license terms, you may also use the software to design, develop and test your programs that you may distribute to third parties or deploy for third parties to access over the Internet, provided that:
-i.	you include in your programs a visible notice to your users that the programs were created with or rely on pre-release, time-sensitive unsupported software that may not operate correctly;
-ii.	if your program requires that certain portions of the software that are not distributable, such as Microsoft Silverlight, be installed on the end user’s computer, you will include a visible notice that your program does not include the relevant software and that the end user will need to obtain a copy of it directly from Microsoft; and
-iii.	you will not make any representation, warranty or promise on behalf of Microsoft or with respect to the software or its performance.
-This right to deploy your programs for external access by third parties does not include the right to deploy programs that are designed for the purpose of hosting other software applications, unless you require those applications, when hosted by your programs, to comply with the restrictions in items c, d, and e below.
-c.	Hazardous Environments.  You may not use the software to design, develop or test programs for hazardous environments requiring fail-safe controls, including without limitation, the design, construction, maintenance or operation of nuclear facilities, aircraft navigation or communication systems, air traffic control, and life support or weapons systems. 
-d.	Personal Information.  You may not use the software to design, develop or test programs that collect personally identifiable or confidential data. 
-e.	Commerce Transactions.  You may not use the software to design, develop or test programs that conduct e-commerce transactions (exchange of goods or services by means of the Internet or other computer networks), including without limitation any shipping, credit card, monetary or other banking transactions.
-4.	CONDITIONS AND LIMITATIONS
-        a.  No Trademark License- This license does not grant you rights to use any contributors’ name, logo, or trademarks.
-        b.  If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
-        c.  If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
-        d.  The software is licensed “as-is.” You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
-        e.  The licenses granted herein extend only to software or derivative works that you create that call services owned or operated by Microsoft and/or Windows Live.
+Copyright 2014 Microsoft Corporation
 
-4.  TERMINATION.  In the event that you sue Microsoft for patent or copyright infringement and assert a claim against the Original Software, a Derived Software Work, an Extensible Licensed Product, or the Licensed Platform, your rights under this agreement, including all copyright and patent licenses from Microsoft, terminate.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-5.	UPDATES; SUBSEQUENT RELEASES.
-a.	If Microsoft makes bug fixes, security fixes or other error corrections to the software, you agree to use commercially reasonable efforts to install or distribute them for purposes of updating the software.
-b.	You understand and agree that the software may change substantially prior to the commercial release of the software and your programs may not work with these later releases of the software.  This agreement does not provide you with any rights to any subsequent pre-release versions or commercial versions, if any.
-6.	FEEDBACK.  If you give feedback about the software to Microsoft, you give to Microsoft, without charge, the right to use, share and commercialize your feedback in any way and for any purpose.  You also give to third parties, without charge, any patent rights needed for their products, technologies and services to use or interface with any specific parts of a Microsoft software or service that includes the feedback.  You will not give feedback that is subject to a license that requires Microsoft to license its software or documentation to third parties because we include your feedback in them.  These rights survive this agreement.
-7.	INTERNET-BASED SERVICES.  Microsoft provides Internet-based services in connection with the software.  It may change or cancel them at any time.  Separate terms of use, available at http://dev.live.com/terms, apply to the services. 
-8.	SCOPE OF LICENSE.  The software is licensed, not sold. This agreement only gives you some rights to use the software.  Microsoft reserves all other rights.  Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement.  In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways.    You may not
-*	disclose the results of any benchmark tests of the software to any third party without Microsoft’s prior written approval;
-*	work around any technical limitations in the software;
-*	reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
-*	make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
-*	publish the software for others to copy;
-*	rent, lease or lend the software;
-*	transfer the software or this agreement to any third party; or
-*	deploy the software on a standalone basis for others to access.
-9.	EXPORT RESTRICTIONS.  The software is subject to United States export laws and regulations.  You must comply with all domestic and international export laws and regulations that apply to the software.  These laws include restrictions on destinations, end users and end use.  For additional information, see www.microsoft.com/exporting.
-10.	SUPPORT SERVICES. Because this software is “as is,” we may not provide support services for it. 
-11.	INDEMNIFICATION.  You agree to indemnify, hold harmless, and defend Microsoft from and against any claims, allegations, lawsuits, losses and costs (including attorney fees) that arise or result from any breach by you of the terms of this agreement.
-12.	ENTIRE AGREEMENT.  This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-13.	APPLICABLE LAW.
-a.	United States.  If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles.  The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
-b.	Outside the United States.  If you acquired the software in any other country, the laws of that country apply.
-14.	LEGAL EFFECT.  This agreement describes certain legal rights.  You may have other rights under the laws of your country.  You may also have rights with respect to the party from whom you acquired the software.  This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
-15.	DISCLAIMER OF WARRANTY.   THE SOFTWARE IS LICENSED “AS-IS.”  YOU BEAR THE RISK OF USING IT.  MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS.  YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS UNDER YOUR LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE.  TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
-16.	LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES.  YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00.  YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
-This limitation applies to
-*	anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and
-*	claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-It also applies even if Microsoft knew or should have known about the possibility of the damages.  The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-Please note: As this software is distributed in Quebec, Canada, some of the clauses in this agreement are provided below in French.
-Remarque : Ce logiciel étant distribué au Québec, Canada, certaines des clauses dans ce contrat sont fournies ci-dessous en français.
-EXONÉRATION DE GARANTIE. Le logiciel visé par une licence est offert « tel quel ». Toute utilisation de ce logiciel est à votre seule risque et péril. Microsoft n’accorde aucune autre garantie expresse. Vous pouvez bénéficier de droits additionnels en vertu du droit local sur la protection des consommateurs, que ce contrat ne peut modifier. La ou elles sont permises par le droit locale, les garanties implicites de qualité marchande, d’adéquation à un usage particulier et d’absence de contrefaçon sont exclues.
-LIMITATION DES DOMMAGES-INTÉRÊTS ET EXCLUSION DE RESPONSABILITÉ POUR LES DOMMAGES.  Vous pouvez obtenir de Microsoft et de ses fournisseurs une indemnisation en cas de dommages directs uniquement à hauteur de 5,00 $ US. Vous ne pouvez prétendre à aucune indemnisation pour les autres dommages, y compris les dommages spéciaux, indirects ou accessoires et pertes de bénéfices.
-Cette limitation concerne :
-*	tout  ce qui est relié au logiciel, aux services ou au contenu (y compris le code) figurant sur des sites Internet tiers ou dans des programmes tiers ; et
-*	les réclamations au titre de violation de contrat ou de garantie, ou au titre de responsabilité stricte, de négligence ou d’une autre faute dans la limite autorisée par la loi en vigueur.
-Elle s’applique également, même si Microsoft connaissait ou devrait connaître l’éventualité d’un tel dommage.  Si votre pays n’autorise pas l’exclusion ou la limitation de responsabilité pour les dommages indirects, accessoires ou de quelque nature que ce soit, il se peut que la limitation ou l’exclusion ci-dessus ne s’appliquera pas à votre égard.
-EFFET JURIDIQUE.  Le présent contrat décrit certains droits juridiques. Vous pourriez avoir d’autres droits prévus par les lois de votre pays.  Le présent contrat ne modifie pas les droits que vous confèrent les lois de votre pays si celles-ci ne le permettent pas.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.mdown
+++ b/README.mdown
@@ -44,3 +44,19 @@ If you reference the iOS API source code directly and you use Xcode 4.2 or later
 ----------------
 
 Visit: http://dev.onedrive.com and click the "Develop” link. 
+
+
+License Agreement
+-----------------
+
+Copyright 2014 Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/LiveSDK/Library/Internal/Helpers/JsonParser.h
+++ b/src/LiveSDK/Library/Internal/Helpers/JsonParser.h
@@ -2,7 +2,19 @@
 //  JsonParser.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+// Copyright 2014 Microsoft Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 // 
 #import <Foundation/Foundation.h>
 

--- a/src/LiveSDK/Library/Internal/Helpers/JsonParser.m
+++ b/src/LiveSDK/Library/Internal/Helpers/JsonParser.m
@@ -2,7 +2,19 @@
 //  JsonParser.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 // 
 
 #import "JsonParser.h"

--- a/src/LiveSDK/Library/Internal/Helpers/JsonWriter.h
+++ b/src/LiveSDK/Library/Internal/Helpers/JsonWriter.h
@@ -2,7 +2,19 @@
 //  JsonWriter.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 // 
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/JsonWriter.m
+++ b/src/LiveSDK/Library/Internal/Helpers/JsonWriter.m
@@ -2,7 +2,19 @@
 //  JsonWriter.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 // 
 
 #import "JsonWriter.h"

--- a/src/LiveSDK/Library/Internal/Helpers/LiveApiHelper.h
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveApiHelper.h
@@ -2,7 +2,19 @@
 //  LiveApiHelper.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/LiveApiHelper.m
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveApiHelper.m
@@ -2,7 +2,19 @@
 //  LiveApiHelper.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthHelper.h"

--- a/src/LiveSDK/Library/Internal/Helpers/LiveAuthHelper.h
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveAuthHelper.h
@@ -2,7 +2,19 @@
 //  LiveAuthHelper.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/LiveAuthHelper.m
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveAuthHelper.m
@@ -2,7 +2,19 @@
 //  LiveAuthHelper.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthHelper.h"

--- a/src/LiveSDK/Library/Internal/Helpers/LiveConnectionCreatorDelegate.h
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveConnectionCreatorDelegate.h
@@ -2,7 +2,19 @@
 //  LiveConnectionCreatorDelegate.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/LiveConnectionHelper.h
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveConnectionHelper.h
@@ -2,7 +2,19 @@
 //  LiveConnectionHelper.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/LiveConnectionHelper.m
+++ b/src/LiveSDK/Library/Internal/Helpers/LiveConnectionHelper.m
@@ -2,7 +2,19 @@
 //  LiveConnectionHelper.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveConnectionHelper.h"

--- a/src/LiveSDK/Library/Internal/Helpers/StreamReader.h
+++ b/src/LiveSDK/Library/Internal/Helpers/StreamReader.h
@@ -2,7 +2,19 @@
 //  StreamReader.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/StreamReader.m
+++ b/src/LiveSDK/Library/Internal/Helpers/StreamReader.m
@@ -2,7 +2,19 @@
 //  StreamReader.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "StreamReader.h"

--- a/src/LiveSDK/Library/Internal/Helpers/StringHelper.h
+++ b/src/LiveSDK/Library/Internal/Helpers/StringHelper.h
@@ -2,7 +2,19 @@
 //  StringHelper.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/StringHelper.m
+++ b/src/LiveSDK/Library/Internal/Helpers/StringHelper.m
@@ -2,7 +2,19 @@
 //  StringHelper.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "StringHelper.h"

--- a/src/LiveSDK/Library/Internal/Helpers/UrlHelper.h
+++ b/src/LiveSDK/Library/Internal/Helpers/UrlHelper.h
@@ -2,7 +2,19 @@
 //  UrlHelper.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/Helpers/UrlHelper.m
+++ b/src/LiveSDK/Library/Internal/Helpers/UrlHelper.m
@@ -2,7 +2,19 @@
 //  UrlHelper.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "UrlHelper.h"

--- a/src/LiveSDK/Library/Internal/LiveAuthDialog.h
+++ b/src/LiveSDK/Library/Internal/LiveAuthDialog.h
@@ -2,7 +2,19 @@
 //  LiveAuthDialog.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/LiveSDK/Library/Internal/LiveAuthDialog.m
+++ b/src/LiveSDK/Library/Internal/LiveAuthDialog.m
@@ -2,7 +2,19 @@
 //  LiveAuthDialog.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthDialog.h"

--- a/src/LiveSDK/Library/Internal/LiveAuthDialogDelegate.h
+++ b/src/LiveSDK/Library/Internal/LiveAuthDialogDelegate.h
@@ -2,7 +2,19 @@
 //  LiveAuthDialogDelegate.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.h
+++ b/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.h
@@ -2,7 +2,19 @@
 //  LiveAuthRefreshRequest.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.m
+++ b/src/LiveSDK/Library/Internal/LiveAuthRefreshRequest.m
@@ -2,7 +2,19 @@
 //  LiveAuthRefreshRequest.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthHelper.h"

--- a/src/LiveSDK/Library/Internal/LiveAuthRequest.h
+++ b/src/LiveSDK/Library/Internal/LiveAuthRequest.h
@@ -2,7 +2,19 @@
 //  LiveAuthRequest.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveAuthRequest.m
+++ b/src/LiveSDK/Library/Internal/LiveAuthRequest.m
@@ -2,7 +2,19 @@
 //  LiveAuthRequest.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthDialogDelegate.h"

--- a/src/LiveSDK/Library/Internal/LiveAuthStorage.h
+++ b/src/LiveSDK/Library/Internal/LiveAuthStorage.h
@@ -2,7 +2,19 @@
 //  LiveAuthStorage.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveAuthStorage.m
+++ b/src/LiveSDK/Library/Internal/LiveAuthStorage.m
@@ -2,7 +2,19 @@
 //  LiveAuthStorage.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthStorage.h"

--- a/src/LiveSDK/Library/Internal/LiveConnectClientCore.h
+++ b/src/LiveSDK/Library/Internal/LiveConnectClientCore.h
@@ -2,7 +2,19 @@
 //  LiveConnectClientCore.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveConnectClientCore.m
+++ b/src/LiveSDK/Library/Internal/LiveConnectClientCore.m
@@ -2,7 +2,19 @@
 //  LiveConnectClientCore.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthHelper.h"

--- a/src/LiveSDK/Library/Internal/LiveConstants.h
+++ b/src/LiveSDK/Library/Internal/LiveConstants.h
@@ -2,7 +2,19 @@
 //  LiveConstants.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveDownloadOperationCore.h
+++ b/src/LiveSDK/Library/Internal/LiveDownloadOperationCore.h
@@ -2,7 +2,19 @@
 //  LiveDownloadOperationCore.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveDownloadOperationCore.m
+++ b/src/LiveSDK/Library/Internal/LiveDownloadOperationCore.m
@@ -2,7 +2,19 @@
 //  LiveDownloadOperationCore.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveApiHelper.h"

--- a/src/LiveSDK/Library/Internal/LiveDownloadOperationInternal.h
+++ b/src/LiveSDK/Library/Internal/LiveDownloadOperationInternal.h
@@ -2,7 +2,19 @@
 //  LiveOperationInternal.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveOperationCore.h
+++ b/src/LiveSDK/Library/Internal/LiveOperationCore.h
@@ -2,7 +2,19 @@
 //  LiveOperationCore.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveOperationCore.m
+++ b/src/LiveSDK/Library/Internal/LiveOperationCore.m
@@ -2,7 +2,19 @@
 //  LiveOperationCore.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveApiHelper.h"

--- a/src/LiveSDK/Library/Internal/LiveOperationInternal.h
+++ b/src/LiveSDK/Library/Internal/LiveOperationInternal.h
@@ -2,7 +2,19 @@
 //  LiveOperationInternal.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveUploadOperationCore.h
+++ b/src/LiveSDK/Library/Internal/LiveUploadOperationCore.h
@@ -2,7 +2,19 @@
 //  LiveUploadOperationCore.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Internal/LiveUploadOperationCore.m
+++ b/src/LiveSDK/Library/Internal/LiveUploadOperationCore.m
@@ -2,7 +2,19 @@
 //  LiveUploadOperationCore.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveApiHelper.h"

--- a/src/LiveSDK/Library/Public/LiveAuthDelegate.h
+++ b/src/LiveSDK/Library/Public/LiveAuthDelegate.h
@@ -2,7 +2,19 @@
 //  LiveAuthDelegate.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveConnectClient.h
+++ b/src/LiveSDK/Library/Public/LiveConnectClient.h
@@ -2,7 +2,19 @@
 //  LiveConnectClient.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveConnectClient.m
+++ b/src/LiveSDK/Library/Public/LiveConnectClient.m
@@ -2,7 +2,19 @@
 //  LiveConnectClient.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //  
 
 #import "LiveApiHelper.h"

--- a/src/LiveSDK/Library/Public/LiveConnectSession.h
+++ b/src/LiveSDK/Library/Public/LiveConnectSession.h
@@ -2,7 +2,19 @@
 //  LiveConnectSession.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveConnectSession.m
+++ b/src/LiveSDK/Library/Public/LiveConnectSession.m
@@ -2,7 +2,19 @@
 //  LiveConnectSession.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveConnectSession.h"

--- a/src/LiveSDK/Library/Public/LiveConnectSessionStatus.h
+++ b/src/LiveSDK/Library/Public/LiveConnectSessionStatus.h
@@ -2,7 +2,19 @@
 //  LiveConnectSessionStatus.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 // An enum type representing the user's session status.

--- a/src/LiveSDK/Library/Public/LiveDownloadOperation.h
+++ b/src/LiveSDK/Library/Public/LiveDownloadOperation.h
@@ -2,7 +2,19 @@
 //  LiveDownloadOperation.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveDownloadOperation.m
+++ b/src/LiveSDK/Library/Public/LiveDownloadOperation.m
@@ -2,7 +2,19 @@
 //  LiveDownloadOperation.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveOperationInternal.h"

--- a/src/LiveSDK/Library/Public/LiveDownloadOperationDelegate.h
+++ b/src/LiveSDK/Library/Public/LiveDownloadOperationDelegate.h
@@ -2,7 +2,19 @@
 //  LiveDownloadOperationListener.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveOperation.h
+++ b/src/LiveSDK/Library/Public/LiveOperation.h
@@ -2,7 +2,19 @@
 //  LiveOperation.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveOperation.m
+++ b/src/LiveSDK/Library/Public/LiveOperation.m
@@ -2,7 +2,19 @@
 //  LiveOperation.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveOperationInternal.h"

--- a/src/LiveSDK/Library/Public/LiveOperationDelegate.h
+++ b/src/LiveSDK/Library/Public/LiveOperationDelegate.h
@@ -2,7 +2,19 @@
 //  LiveOperationDelegate.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveOperationProgress.h
+++ b/src/LiveSDK/Library/Public/LiveOperationProgress.h
@@ -2,7 +2,19 @@
 //  LiveOperationProgress.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveOperationProgress.m
+++ b/src/LiveSDK/Library/Public/LiveOperationProgress.m
@@ -2,7 +2,19 @@
 //  LiveOperationProgress.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveOperationProgress.h"

--- a/src/LiveSDK/Library/Public/LiveUploadOperationDelegate.h
+++ b/src/LiveSDK/Library/Public/LiveUploadOperationDelegate.h
@@ -2,7 +2,19 @@
 //  LiveUploadOperationDelegate.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/Library/Public/LiveUploadOverwriteOption.h
+++ b/src/LiveSDK/Library/Public/LiveUploadOverwriteOption.h
@@ -2,8 +2,19 @@
 //  LiveUploadOverwriteOption.h
 //  Live SDK for iOS
 //
-//  Created by Lin Wang on 6/26/12.
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 // An enum type representing the overwrite options for upload methods.

--- a/src/LiveSDK/deleted/LiveAppDelegate.h
+++ b/src/LiveSDK/deleted/LiveAppDelegate.h
@@ -2,7 +2,19 @@
 //  LiveAppDelegate.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/LiveSDK/deleted/LiveAppDelegate.m
+++ b/src/LiveSDK/deleted/LiveAppDelegate.m
@@ -2,7 +2,19 @@
 //  LiveAppDelegate.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAppDelegate.h"

--- a/src/LiveSDK/deleted/LiveServiceViewController.h
+++ b/src/LiveSDK/deleted/LiveServiceViewController.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/LiveSDK/deleted/LiveServiceViewController.m
+++ b/src/LiveSDK/deleted/LiveServiceViewController.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController.h"

--- a/src/LiveSDK/deleted/iPad/LiveServiceViewController_iPad.h
+++ b/src/LiveSDK/deleted/iPad/LiveServiceViewController_iPad.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPad.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/LiveSDK/deleted/iPad/LiveServiceViewController_iPad.m
+++ b/src/LiveSDK/deleted/iPad/LiveServiceViewController_iPad.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPad.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController_iPad.h"

--- a/src/LiveSDK/deleted/iPhone/LiveServiceViewController_iPhone.h
+++ b/src/LiveSDK/deleted/iPhone/LiveServiceViewController_iPhone.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPhone.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/LiveSDK/deleted/iPhone/LiveServiceViewController_iPhone.m
+++ b/src/LiveSDK/deleted/iPhone/LiveServiceViewController_iPhone.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPhone.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController_iPhone.h"

--- a/src/LiveSDK/deleted/main.m
+++ b/src/LiveSDK/deleted/main.m
@@ -2,7 +2,19 @@
 //  main.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/LiveSDK_framework/LiveSDK_framework-Info.plist
+++ b/src/LiveSDK_framework/LiveSDK_framework-Info.plist
@@ -41,6 +41,6 @@
 	<key>CFPlugInUnloadFunction</key>
 	<string></string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2011 Microsoft. All rights reserved.</string>
+	<string>Copyright © 2014 Microsoft. Licensed under the Apache License, Version 2.0.</string>
 </dict>
 </plist>

--- a/src/LiveSDK_framework/LiveSDK_framework-Prefix.pch
+++ b/src/LiveSDK_framework/LiveSDK_framework-Prefix.pch
@@ -1,3 +1,17 @@
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 //
 // Prefix header for all source files of the 'LiveSDKForiOS' target in the 'LiveSDKForiOS' project
 //

--- a/src/Samples/PhotoSky/PhotoSky/PSAppDelegate.h
+++ b/src/Samples/PhotoSky/PhotoSky/PSAppDelegate.h
@@ -2,7 +2,19 @@
 //  PSAppDelegate.h
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/PhotoSky/PhotoSky/PSAppDelegate.m
+++ b/src/Samples/PhotoSky/PhotoSky/PSAppDelegate.m
@@ -2,7 +2,19 @@
 //  PSAppDelegate.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "PSAppDelegate.h"

--- a/src/Samples/PhotoSky/PhotoSky/PSMainViewController.h
+++ b/src/Samples/PhotoSky/PhotoSky/PSMainViewController.h
@@ -2,7 +2,19 @@
 //  PSMainViewController.h
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/PhotoSky/PhotoSky/PSMainViewController.m
+++ b/src/Samples/PhotoSky/PhotoSky/PSMainViewController.m
@@ -2,7 +2,19 @@
 //  PSMainViewController.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "PSMainViewController.h"

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyDriveFolderPicker.h
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyDriveFolderPicker.h
@@ -2,7 +2,19 @@
 //  PSSkyDriveFolderPicker.h
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyDriveFolderPicker.m
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyDriveFolderPicker.m
@@ -2,7 +2,19 @@
 //  PSSkyDriveFolderPicker.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "PSSkyDriveFolderPicker.h"

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyDriveObject.h
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyDriveObject.h
@@ -2,7 +2,19 @@
 //  PSFolder.h
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyDriveObject.m
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyDriveObject.m
@@ -2,7 +2,19 @@
 //  PSFolder.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "PSSkyDriveObject.h"

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyPhotoViewer.h
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyPhotoViewer.h
@@ -2,7 +2,19 @@
 //  PSSkyPhotoViewer.h
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/PhotoSky/PhotoSky/PSSkyPhotoViewer.m
+++ b/src/Samples/PhotoSky/PhotoSky/PSSkyPhotoViewer.m
@@ -2,7 +2,19 @@
 //  PSSkyPhotoViewer.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "PSSkyPhotoViewer.h"

--- a/src/Samples/PhotoSky/PhotoSky/PhotoSky-Prefix.pch
+++ b/src/Samples/PhotoSky/PhotoSky/PhotoSky-Prefix.pch
@@ -1,3 +1,17 @@
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
 //
 // Prefix header for all source files of the 'PhotoSky' target in the 'PhotoSky' project
 //

--- a/src/Samples/PhotoSky/PhotoSky/main.m
+++ b/src/Samples/PhotoSky/PhotoSky/main.m
@@ -2,7 +2,19 @@
 //  main.m
 //  PhotoSky
 //
-//  Copyright (c) 2012 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/TestBed/LiveAppDelegate.h
+++ b/src/Samples/TestBed/LiveAppDelegate.h
@@ -2,7 +2,19 @@
 //  LiveAppDelegate.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/TestBed/LiveAppDelegate.m
+++ b/src/Samples/TestBed/LiveAppDelegate.m
@@ -2,7 +2,19 @@
 //  LiveAppDelegate.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAppDelegate.h"

--- a/src/Samples/TestBed/LiveServiceViewController.h
+++ b/src/Samples/TestBed/LiveServiceViewController.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/Samples/TestBed/LiveServiceViewController.m
+++ b/src/Samples/TestBed/LiveServiceViewController.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController.h"

--- a/src/Samples/TestBed/iPad/LiveServiceViewController_iPad.h
+++ b/src/Samples/TestBed/iPad/LiveServiceViewController_iPad.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPad.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/TestBed/iPad/LiveServiceViewController_iPad.m
+++ b/src/Samples/TestBed/iPad/LiveServiceViewController_iPad.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPad.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController_iPad.h"

--- a/src/Samples/TestBed/iPhone/LiveServiceViewController_iPhone.h
+++ b/src/Samples/TestBed/iPhone/LiveServiceViewController_iPhone.h
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPhone.h
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/Samples/TestBed/iPhone/LiveServiceViewController_iPhone.m
+++ b/src/Samples/TestBed/iPhone/LiveServiceViewController_iPhone.m
@@ -2,7 +2,19 @@
 //  LiveServiceViewController_iPhone.m
 //  Live SDK for iOS sample code
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveServiceViewController_iPhone.h"

--- a/src/Samples/TestBed/main.m
+++ b/src/Samples/TestBed/main.m
@@ -2,7 +2,19 @@
 //  main.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <UIKit/UIKit.h>

--- a/src/UnitTests/LiveAuthHelperTests.h
+++ b/src/UnitTests/LiveAuthHelperTests.h
@@ -2,7 +2,19 @@
 //  LiveAuthHelperTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/LiveAuthHelperTests.m
+++ b/src/UnitTests/LiveAuthHelperTests.m
@@ -2,7 +2,19 @@
 //  LiveAuthHelperTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthHelper.h"

--- a/src/UnitTests/LiveAuthStorageTests.h
+++ b/src/UnitTests/LiveAuthStorageTests.h
@@ -2,7 +2,19 @@
 //  LiveAuthStorageTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/LiveAuthStorageTests.m
+++ b/src/UnitTests/LiveAuthStorageTests.m
@@ -2,7 +2,19 @@
 //  LiveAuthStorageTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveAuthStorageTests.h"

--- a/src/UnitTests/LiveConnectClientApiTests.h
+++ b/src/UnitTests/LiveConnectClientApiTests.h
@@ -2,7 +2,19 @@
 //  LiveConnectClientApiTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/LiveConnectClientApiTests.m
+++ b/src/UnitTests/LiveConnectClientApiTests.m
@@ -2,7 +2,19 @@
 //  LiveConnectClientApiTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "JsonWriter.h"

--- a/src/UnitTests/LiveConnectClientAuthTests.h
+++ b/src/UnitTests/LiveConnectClientAuthTests.h
@@ -2,7 +2,19 @@
 //  LiveConnectClientAuthTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/LiveConnectClientAuthTests.m
+++ b/src/UnitTests/LiveConnectClientAuthTests.m
@@ -2,7 +2,19 @@
 //  LiveAuthRefreshRequestTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "JsonWriter.h"

--- a/src/UnitTests/LiveConnectClientListener.h
+++ b/src/UnitTests/LiveConnectClientListener.h
@@ -2,7 +2,19 @@
 //  LiveConnectClientListener.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/UnitTests/LiveConnectClientListener.m
+++ b/src/UnitTests/LiveConnectClientListener.m
@@ -2,7 +2,19 @@
 //  LiveConnectClientListener.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "LiveConnectClientListener.h"

--- a/src/UnitTests/MockFactory.h
+++ b/src/UnitTests/MockFactory.h
@@ -2,7 +2,19 @@
 //  MockFactory.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/UnitTests/MockFactory.m
+++ b/src/UnitTests/MockFactory.m
@@ -2,7 +2,19 @@
 //  MockFactory.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "MockFactory.h"

--- a/src/UnitTests/MockResponse.h
+++ b/src/UnitTests/MockResponse.h
@@ -2,7 +2,19 @@
 //  MockResponse.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <Foundation/Foundation.h>

--- a/src/UnitTests/MockResponse.m
+++ b/src/UnitTests/MockResponse.m
@@ -2,7 +2,19 @@
 //  MockResponse.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "MockResponse.h"

--- a/src/UnitTests/MockUrlConnection.h
+++ b/src/UnitTests/MockUrlConnection.h
@@ -2,7 +2,19 @@
 //  LiveSDKTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import <SenTestingKit/SenTestingKit.h>

--- a/src/UnitTests/MockUrlConnection.m
+++ b/src/UnitTests/MockUrlConnection.m
@@ -2,7 +2,19 @@
 //  LiveSDKTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "MockUrlConnection.h"

--- a/src/UnitTests/StringHelperTests.h
+++ b/src/UnitTests/StringHelperTests.h
@@ -2,7 +2,19 @@
 //  StringHelperTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/StringHelperTests.m
+++ b/src/UnitTests/StringHelperTests.m
@@ -2,7 +2,19 @@
 //  StringHelperTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "StringHelperTests.h"

--- a/src/UnitTests/UrlHelperTests.h
+++ b/src/UnitTests/UrlHelperTests.h
@@ -2,7 +2,19 @@
 //  UrlHelperTests.h
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 //  Logic unit tests contain unit test code that is designed to be linked into an independent test executable.

--- a/src/UnitTests/UrlHelperTests.m
+++ b/src/UnitTests/UrlHelperTests.m
@@ -2,7 +2,19 @@
 //  UrlHelperTests.m
 //  Live SDK for iOS
 //
-//  Copyright (c) 2011 Microsoft Corp. All rights reserved.
+//  Copyright 2014 Microsoft Corporation
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
 #import "UrlHelper.h"


### PR DESCRIPTION
Updated the code files to refer to the Apache 2.0 license. I didn't update the contents of /bin/ since I'm not sure what the purpose of that folder is.

Do we need to rebuild the framework and include it in the zip post these changes so the headers in the binary pick up the new license?
