### PR TITLE
Allow bypassing the plist storage for refreshToken

### DIFF
--- a/src/LiveSDK/Library/Internal/LiveConnectClientCore.h
+++ b/src/LiveSDK/Library/Internal/LiveConnectClientCore.h
@@ -54,6 +54,10 @@
                delegate:(id<LiveAuthDelegate>)delegate
               userState:(id)userState;
 
+- (id) initWithClientId:(NSString *)clientId
+                 scopes:(NSArray *)scopes
+               delegate:(id<LiveAuthDelegate>)delegate;
+
 - (void) login:(UIViewController *)currentViewController
         scopes:(NSArray *)scopes
       delegate:(id<LiveAuthDelegate>)delegate
@@ -63,6 +67,10 @@
                   userState:(id)userState;
 
 - (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
+                          userState:(id)userState;
+
+- (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
+                       refreshToken:(NSString *)refreshToken
                           userState:(id)userState;
 
 - (LiveOperation *) sendRequestWithMethod:(NSString *)method

--- a/src/LiveSDK/Library/Internal/LiveConnectClientCore.m
+++ b/src/LiveSDK/Library/Internal/LiveConnectClientCore.m
@@ -55,6 +55,24 @@
     return self;
 }
 
+
+- (id) initWithClientId:(NSString *)clientId
+                 scopes:(NSArray *)scopes
+               delegate:(id<LiveAuthDelegate>)delegate
+{
+    self = [super init];
+    if (self)
+    {
+        _clientId = [clientId copy];
+        _scopes = [scopes copy];
+        _storage = nil; // Let the developer choose whether they want to save the refreshToken, where and when.
+        _status = LiveAuthUnknown;
+        _session = nil;
+    }
+    
+    return self;
+}
+
 - (void)dealloc
 {
     [authRefreshRequest cancel];
@@ -138,19 +156,26 @@
         _status = LiveAuthConnected;
     }
     
-    // By the time we update the session, we persist the refreshToken.
+    // By the time we update the session, we persist the refreshToken - that is if the developer has chosen to use storage.
     _storage.refreshToken = session.refreshToken;
 }
 
 - (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
                           userState:(id)userState
 {
-    if ([LiveAuthHelper shouldRefreshToken:_session 
-                              refreshToken:_storage.refreshToken]) 
+    [self refreshSessionWithDelegate:delegate refreshToken:_storage.refreshToken userState:userState];
+}
+
+- (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
+                       refreshToken:(NSString *)refreshToken
+                          userState:(id)userState
+{
+    if ([LiveAuthHelper shouldRefreshToken:_session
+                              refreshToken:refreshToken])
     {
         authRefreshRequest = [[[LiveAuthRefreshRequest alloc] initWithClientId:_clientId
                                                                          scope:_scopes
-                                                                  refreshToken:_storage.refreshToken
+                                                                  refreshToken:refreshToken
                                                                       delegate:delegate
                                                                      userState:userState
                                                                     clientStub:self]
@@ -160,11 +185,11 @@
     }
     else
     {
-        if ([delegate respondsToSelector:@selector(authCompleted:session:userState:)]) 
+        if ([delegate respondsToSelector:@selector(authCompleted:session:userState:)])
         {
             NSArray *authCompletedEvent = [NSArray arrayWithObjects:delegate, userState, nil];
-            [self performSelector:@selector(sendAuthCompletedMessage:) 
-                       withObject:authCompletedEvent 
+            [self performSelector:@selector(sendAuthCompletedMessage:)
+                       withObject:authCompletedEvent
                        afterDelay:0.1];
         }
     }

--- a/src/LiveSDK/Library/Public/LiveConnectClient.h
+++ b/src/LiveSDK/Library/Public/LiveConnectClient.h
@@ -60,6 +60,9 @@
 //         the server will reject to send back authentication session data.
 // - userState: Optional. An object that is used to track asynchronous state. The userState object will 
 //         be passed as userState parameter when any LiveAuthDelegate protocol method is invoked.
+//
+// If initManuallyWithClientId: is sent, then the authorization process will not start immediately,
+// and you have to send refreshSessionWithDelegate:refreshtoken:userState: in order to start the process of validating the token.
 
 - (id) initWithClientId:(NSString *)clientId
                delegate:(id<LiveAuthDelegate>)delegate;
@@ -76,6 +79,18 @@
                  scopes:(NSArray *)scopes
                delegate:(id<LiveAuthDelegate>)delegate
               userState:(id)userState;
+
+- (id) initManuallyWithClientId:(NSString *)clientId
+                         scopes:(NSArray *)scopes
+                       delegate:(id<LiveAuthDelegate>)delegate;
+
+#pragma mark - refresh* methods
+
+- (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
+                       refreshToken:(NSString *)refreshToken
+                          userState:(id)userState;
+
+- (NSString *) refreshToken;
 
 #pragma mark - login* methods
 

--- a/src/LiveSDK/Library/Public/LiveConnectClient.m
+++ b/src/LiveSDK/Library/Public/LiveConnectClient.m
@@ -92,11 +92,40 @@
     return self;
 }
 
+- (id) initManuallyWithClientId:(NSString *)clientId
+                         scopes:(NSArray *)scopes
+                       delegate:(id<LiveAuthDelegate>)delegate
+{
+    self = [super init];
+    if (self)
+    {
+        _liveClientCore = [[LiveConnectClientCore alloc] initWithClientId:clientId
+                                                                   scopes:[LiveAuthHelper normalizeScopes:scopes]
+                                                                 delegate:delegate];
+    }
+    
+    return self;
+}
+
 - (void)dealloc
 {
     [_liveClientCore release];
     
     [super dealloc];
+}
+
+#pragma mark Refresh stuff
+
+- (void) refreshSessionWithDelegate:(id<LiveAuthDelegate>)delegate
+                       refreshToken:(NSString *)refreshToken
+                          userState:(id)userState
+{
+    [_liveClientCore refreshSessionWithDelegate:delegate refreshToken:refreshToken userState:userState];
+}
+
+- (NSString *) refreshToken
+{
+    return self.session.refreshToken;
 }
 
 #pragma mark Parameter validation


### PR DESCRIPTION
We need to let the developer choose when to refresh and when and where to save the refreshToken - as an alternative to using the plist storage.
