### PR TITLE
OneNote development still supports the Live SDK

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -1,12 +1,14 @@
-Annoucement: There's a new OneDrive SDK
+Announcement: There's a new OneDrive SDK
 ================
 
 The Live SDK has been replaced by the [OneDrive API](https://dev.onedrive.com) and 
-[OneDrive SDK for iOS](https://github.com/OneDrive/onedrive-sdk-ios). All new projects
+[OneDrive SDK for iOS](https://github.com/OneDrive/onedrive-sdk-ios). All new OneDrive development
 should use the OneDrive API to integrate with OneDrive instead of Live SDK.
 
-This Live SDK project will remain available for existing applications to continue to use
+This Live SDK project will remain available for existing OneDrive applications to continue to use
 but new application development should be done using the OneDrive SDK.
+
+The Live SDK is still applicable for OneNote development.
 
 
 Live SDK for iOS (legacy)


### PR DESCRIPTION
Edited the "new OneDrive SDK" note to clarify that OneNote apps can continue to use the Live SDK.
