### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -32,7 +32,7 @@ For questions on how to use the sdk visit http://stackoverflow.com/questions/tag
 
 You can reference the iOS API in two ways.
 
-###2.1 Install with Cocoapods
+###2.1 Install with CocoaPods
 
 * [Install cocoapods](http://guides.cocoapods.org/using/getting-started.html) following the getting started guide.
 * Add the following to your Podfile: `pod 'LiveSDK'`


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
